### PR TITLE
Add Equatable conformance to service call errors

### DIFF
--- a/Source/ServiceCalls/ServiceCaller.swift
+++ b/Source/ServiceCalls/ServiceCaller.swift
@@ -7,13 +7,13 @@
 
 import Foundation
 
-public enum ServiceCallError: Error {
+public enum ServiceCallError: Error, Equatable {
   case noDataAvailable
   case generalError
   case malformedRequest
 }
 
-public enum SerivceCallerSetupError: Error {
+public enum SerivceCallerSetupError: Error, Equatable {
   case noCallSucceededCallback
   case noCallFailedCallback
 }


### PR DESCRIPTION
<h1>Overview</h1>
Add Equatable to service call errors to ensure that unit testing can be done on error throwing