### PR TITLE
Update ServiceCaller to handle POST requests

### DIFF
--- a/Source/ServiceCalls/ServiceCaller.swift
+++ b/Source/ServiceCalls/ServiceCaller.swift
@@ -18,16 +18,24 @@ public enum SerivceCallerSetupError: Error, Equatable {
   case noCallFailedCallback
 }
 
+public struct DataBundleKeys {
+  static let postParameters: String = "parameters"
+}
+
 public class ServiceCaller {
   
   public var callSucceeded: ((Data, DataBundle) -> Void)?
   public var callFailed: ((ServiceCallError) -> Void)?
   
-  public func makeServiceCall(with url: URL, and dataBundle: DataBundle) throws {
+  public func makeServiceCall(with url: URL,
+                              and dataBundle: DataBundle,
+                              usingMethod method: String = "GET") throws {
     
     try checkIfCallerIsSetUp()
     
-    let task = URLSession.shared.dataTask(with: url) { (data, response, error) in
+    let request = setUpRequest(withURL: url, andWithMethod: method, andWithData: dataBundle)
+    
+    let task = URLSession.shared.dataTask(with: request) { (data, response, error) in
 
       if error != nil {
         
@@ -55,6 +63,34 @@ public class ServiceCaller {
       
   }
   
+  private func setUpRequest(withURL url: URL,
+                            andWithMethod method: String,
+                            andWithData data: DataBundle) -> URLRequest {
+    
+    var request = URLRequest(url: url)
+    request.httpMethod = method
+    
+    if method == "POST" {
+      post(request: &request, andWithData: data)
+    }
+    
+    return request
+    
+  }
+  
+  private func post(request: inout URLRequest,
+                    andWithData data: DataBundle) {
+    
+    request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+    
+    let parameters: [String: Any] = data.extraData[DataBundleKeys.postParameters]
+                                    as? [String : Any] ?? [:]
+    data.extraData.removeValue(forKey: DataBundleKeys.postParameters)
+    
+    request.httpBody = parameters.percentEncoded()
+    
+  }
+  
   private func checkIfCallerIsSetUp() throws {
     
     guard callSucceeded != nil else {
@@ -74,4 +110,27 @@ public class ServiceCaller {
     
   }
   
+}
+
+extension Dictionary {
+    func percentEncoded() -> Data? {
+        return map { key, value in
+            let escapedKey = "\(key)".addingPercentEncoding(withAllowedCharacters: .urlQueryValueAllowed) ?? ""
+            let escapedValue = "\(value)".addingPercentEncoding(withAllowedCharacters: .urlQueryValueAllowed) ?? ""
+            return escapedKey + "=" + escapedValue
+        }
+        .joined(separator: "&")
+        .data(using: .utf8)
+    }
+}
+
+extension CharacterSet {
+    static let urlQueryValueAllowed: CharacterSet = {
+        let generalDelimitersToEncode = ":#[]@" // does not include "?" or "/" due to RFC 3986 - Section 3.4
+        let subDelimitersToEncode = "!$&'()*+,;="
+
+        var allowed = CharacterSet.urlQueryAllowed
+        allowed.remove(charactersIn: "\(generalDelimitersToEncode)\(subDelimitersToEncode)")
+        return allowed
+    }()
 }

--- a/Source/ServiceCalls/ServiceCaller.swift
+++ b/Source/ServiceCalls/ServiceCaller.swift
@@ -84,7 +84,7 @@ public class ServiceCaller {
     request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
     
     let parameters: [String: Any] = data.extraData[DataBundleKeys.postParameters]
-                                    as? [String : Any] ?? [:]
+                                    as? [String: Any] ?? [:]
     data.extraData.removeValue(forKey: DataBundleKeys.postParameters)
     
     request.httpBody = parameters.percentEncoded()


### PR DESCRIPTION
<h1>Overview</h1>
Update the service caller to handle POST requests without breaking the existing calls to the service caller.

<h2>Details</h2>
When making a service call it is possible to make a POST request by specifying the method when making the service call and also adding a <String: Any> Dictionary to the DataBundle with the key provided by DataBundleKeys for parameters.