### PR TITLE
Update URL paths to point to the Horoku hosted API

### DIFF
--- a/Source/Login/Repositories/LoginAPIRepo.swift
+++ b/Source/Login/Repositories/LoginAPIRepo.swift
@@ -7,10 +7,6 @@
 
 import Foundation
 
-struct LoginPaths {
-  static let loginPath = "http://localhost:8080/login"
-}
-
 private struct JSONLoginResult: Codable {
   let can_login: Bool
 }
@@ -38,7 +34,7 @@ extension LoginAPIRepo: LoginRepositoryType {
                            andPassword password: String,
                            using serviceCaller: ServiceCaller) {
     
-    guard let url = URL(string: LoginPaths.loginPath) else {
+    guard let url = URL(string: FeistyAPIURLComponents.loginURL) else {
       return
     }
     

--- a/Source/ServiceCalls/FeistyAPIURLComponents.swift
+++ b/Source/ServiceCalls/FeistyAPIURLComponents.swift
@@ -9,14 +9,15 @@ import Foundation
 
 struct FeistyAPIURLComponents {
   
-  static let httpProtocol = "http://"
-  static let domainName = "localhost"
-  static let portNumber = ":8080"
+  private static let httpProtocol = "https://"
+  private static let domainName = "feisty-server.herokuapp.com"
   
-  static let friendsPath = "friends"
+  private static let friendsPath = "friends"
+  private static let loginPath = "login"
   
-  static let protocolAndHostName = httpProtocol + domainName + portNumber
+  private static let protocolAndHostName = httpProtocol + domainName
   
   static let getFriendList = "\(protocolAndHostName)/\(friendsPath)"
+  static let loginURL = "\(protocolAndHostName)/\(loginPath)"
   
 }


### PR DESCRIPTION
<h1>Overview</h1>
Update URL paths to point to the Horoku hosted API and make login use the same URL  components for consistency.