### PR TITLE
Tech Debt was removed

### DIFF
--- a/Example/Tests/GameTests/GameClassTest.swift
+++ b/Example/Tests/GameTests/GameClassTest.swift
@@ -42,18 +42,4 @@ class GameClassTest: XCTestCase {
     
   }
   
-  func testGivenGameWhenToStringIsCalledThenDisplayGameName() {
-    
-    let testPrice = 200.00
-    let testAppID = "5510256"
-    let testName = "Pirates of Las Angeles"
-    let systemUnderTest = Game(gameName: testName, gamePrice: testPrice)
-    systemUnderTest.appID = testAppID
-    
-    let result = systemUnderTest.toString()
-    
-    XCTAssert(result == testName)
-    
-  }
-  
 }

--- a/Example/Tests/GameViewTests/GameDetailsTests/MockGameDetailsLoadedType.swift
+++ b/Example/Tests/GameViewTests/GameDetailsTests/MockGameDetailsLoadedType.swift
@@ -14,7 +14,7 @@ class MockGameDetailsLoadedType: NSObject, GameDetailsLoadedType {
   var gameDetailsFoundCalled: Bool = false
   var gameDetailsIsDefault: Bool = true
   
-  func gameDetailsFound(_ withGameName: String, _ andAppID: String, _ price: String, _ shortDescription: String, _ developers: String, _ publishers: String, _ headerImage: UIImage) {
+  func gameDetailsFound(_ withGameName: String, _ andAppID: String, _ price: String, _ shortDescription: String, _ developers: String, _ publishers: String, _ headerImage: UIImage?) {
     
     gameDetailsFoundCalled = true
     

--- a/Example/Tests/GameViewTests/GameListTests/Model/GameModelTests.swift
+++ b/Example/Tests/GameViewTests/GameListTests/Model/GameModelTests.swift
@@ -71,21 +71,21 @@ class GameModelTests: XCTestCase {
   
   func testGameModelGamesLoadedSubscription() {
     
-    systemUnderTest.subscribeToGameModelGamesLoaded(subscriber: mockGameViewModel, subscriberID: "Mock View Model")
+    systemUnderTest.subscribeToModel(subscriber: mockGameViewModel)
     systemUnderTest.loadData()
-    
+     
     XCTAssertTrue(mockGameViewModel.gamesFinishedLoadingCalled)
     
   }
   
   func testGameModelGamesLoadedUnsubscribe() {
     
-    systemUnderTest.subscribeToGameModelGamesLoaded(subscriber: mockGameViewModel, subscriberID: "Mock View Model")
+    systemUnderTest.subscribeToModel(subscriber: mockGameViewModel)
     systemUnderTest.loadData()
     
     XCTAssertTrue(mockGameViewModel.gamesFinishedLoadingCalled)
     
-    systemUnderTest.unsubscribeFromGameModelGamesLoaded(subscriberID: "Mock View Model")
+    systemUnderTest.unsubscribeFromModel()
     systemUnderTest.loadData()
     
     XCTAssertTrue(mockGameViewModel.gamesFinishedLoadingCalled)

--- a/Example/Tests/GameViewTests/GameListTests/Model/MockGameRepo.swift
+++ b/Example/Tests/GameViewTests/GameListTests/Model/MockGameRepo.swift
@@ -11,7 +11,7 @@ import CommonFiles
 
 class MockGameRepo {
   
-  var gamesLoadedObservers: [String: GameRepositoryObserver] = [:]
+  var observer: GameRepositoryObserver?
   var gameList: [Game] = []
   var getGameListCalled = false
   var getGameDetailsCalled = false
@@ -39,28 +39,24 @@ extension MockGameRepo: GameRepository {
   func getGameList(with serviceCaller: ServiceCaller) {
     
     getGameListCalled = true
-    gamesLoadedObservers.forEach {_, observer in
-      observer.gameListFinishedLoading(withData: gameList)
-    }
+    observer?.gameListFinishedLoading(withData: gameList)
     
   }
   
   func getGameDetails(of gameList: [Game], with serviceCaller: ServiceCaller) {
     
     getGameDetailsCalled = true
-    gamesLoadedObservers.forEach {_, observer in
-      observer.gameDetailsFinishedLoading(withData: self.gameList)
-    }
+    observer?.gameDetailsFinishedLoading(withData: self.gameList)
     
   }
   
-  func subscribeToGameRepoGamesLoaded(subscriber observer: GameRepositoryObserver, subscriberID observerID: String) {
-    gamesLoadedObservers[observerID] = observer
+  func subscribeToRepository(subscriber observer: GameRepositoryObserver) {
+    self.observer = observer
     subscriberAdded = true
   }
   
-  func unsubscribeFromGameRepoGamesLoaded(subscriberID observerID: String) {
-    gamesLoadedObservers.removeValue(forKey: observerID)
+  func unsubscribeFromRepository() {
+    observer = nil
     subscriberAdded = false
   }
   

--- a/Example/Tests/GameViewTests/GameListTests/ViewModel/MockGameModel.swift
+++ b/Example/Tests/GameViewTests/GameListTests/ViewModel/MockGameModel.swift
@@ -11,7 +11,7 @@ import XCTest
 
 class MockGameModel: GameModelProtocol {
   var gameList: [Game] = []
-  var gameLoadedObservers: [String: GameModelObserver] = [:]
+  var observer: GameModelObserver?
   
   func loadData() {
     gameList.append(Game(appid: "1", name: "Game One"))
@@ -27,9 +27,7 @@ class MockGameModel: GameModelProtocol {
   }
   
   func notifyGameLoadedObservers() {
-    gameLoadedObservers.forEach { _, observer in
-      observer.gamesFinishedLoading()
-    }
+    observer?.gamesFinishedLoading()
   }
   
   func getGameAt(index: Int) -> Game {
@@ -49,12 +47,12 @@ class MockGameModel: GameModelProtocol {
     return gameList.count
   }
   
-  func subscribeToGameModelGamesLoaded(subscriber observer: GameModelObserver, subscriberID observerID: String) {
-    gameLoadedObservers[observerID] = observer
+  func subscribeToModel(subscriber observer: GameModelObserver) {
+    self.observer = observer
   }
   
-  func unsubscribeFromGameModelGamesLoaded(subscriberID observerID: String) {
-    gameLoadedObservers.removeValue(forKey: observerID)
+  func unsubscribeFromModel() {
+    observer = nil
   }
   
 }

--- a/Source/CoreClasses/Game.swift
+++ b/Source/CoreClasses/Game.swift
@@ -56,8 +56,4 @@ public class Game: NSObject {
 
   }
 
-  public func toString() -> String {
-    return name
-  }
-  
 }

--- a/Source/Friends/FriendList/Repository/FriendImageRepo/FriendImageAPIRepo.swift
+++ b/Source/Friends/FriendList/Repository/FriendImageRepo/FriendImageAPIRepo.swift
@@ -50,7 +50,7 @@ extension FriendImageAPIRepo: FriendImageRepositoryType {
     }
     
     do {
-      try serviceCaller.makeServiceCall(with: url, and: dataBundle, usingMethod: "POST")
+      try serviceCaller.makeServiceCall(with: url, and: dataBundle, usingMethod: .post)
     } catch {
       return
     }

--- a/Source/Friends/FriendList/Repository/FriendListRepo/FriendListAPIRepo.swift
+++ b/Source/Friends/FriendList/Repository/FriendListRepo/FriendListAPIRepo.swift
@@ -7,30 +7,28 @@
 
 import Foundation
 
-private struct JSONFriendList: Codable {
-  
-  let users: [JSONFriend]
-  
-}
+public class FriendListAPIRepo {
 
-private struct JSONFriend: Codable {
-  
-  let userID: String
-  let username: String
-  let status: String
-  
-  private enum CodingKeys: String, CodingKey {
+  struct JSONFriendList: Codable {
+    let users: [JSONFriend]
+  }
+
+  struct JSONFriend: Codable {
     
-    case userID = "user_id"
-    case username
-    case status
+    let userID: String
+    let username: String
+    let status: String
+    
+    private enum CodingKeys: String, CodingKey {
+      
+      case userID = "user_id"
+      case username
+      case status
+      
+    }
     
   }
-  
-}
 
-public class FriendListAPIRepo {
-  
   public weak var observer: FriendListRepoObserver?
   
   public init() { }
@@ -60,22 +58,17 @@ extension FriendListAPIRepo: FriendListRepositoryType {
     serviceCaller.callSucceeded = { data, dataBundle in
       
       let friendList = self.decodeFriendList(data: data)
-      
       self.observer?.friendsListRetrieved(withData: friendList)
       
     }
     
     serviceCaller.callFailed = { error in
-      
       self.observer?.failedToLoadFriends()
-      
     }
     
     do {
       try serviceCaller.makeServiceCall(with: friendsURL, and: dataBundle)
-    } catch {
-      
-    }
+    } catch { }
     
   }
   

--- a/Source/GameDetails/ObjCGameDetails/GameDetailsLoadedType.h
+++ b/Source/GameDetails/ObjCGameDetails/GameDetailsLoadedType.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
                         : (NSString *) shortDescription
                         : (NSString *) developers
                         : (NSString *) publishers
-                        : (UIImage *) headerImage;
+                        : (UIImage * _Nullable)  headerImage;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/GameView/GameViewModels/GameDataViewModel.swift
+++ b/Source/GameView/GameViewModels/GameDataViewModel.swift
@@ -11,7 +11,6 @@ import Foundation
 ///The class represents the data of the ViewModel and delegates work between the View and the Model
 public class GameDataViewModel {
   
-  public var observerID: String = "GameDataViewModelSubscriber"
   private weak var view: GameDataLoadedType?
   private var model: GameModelProtocol
   
@@ -19,7 +18,7 @@ public class GameDataViewModel {
     self.view = view
     self.model = model
     
-    model.subscribeToGameModelGamesLoaded(subscriber: self, subscriberID: observerID)
+    model.subscribeToModel(subscriber: self)
     model.loadData()
     
   }
@@ -70,9 +69,7 @@ extension GameDataViewModel: GameModelObserver {
   }
   
   public func gamesFinishedLoading() {
-    
     view?.gameDataSuccessfullyLoaded(with: model.gameList)
-    
   }
   
 }

--- a/Source/GameView/Models/GameModel.swift
+++ b/Source/GameView/Models/GameModel.swift
@@ -12,27 +12,22 @@ import Foundation
 public class GameModel {
   
   private let repo: GameRepository
-  public var observerID: String = "GameModelObserver"
   private let imageRepo: GameImageRepositoryType
+  public var gameList: [Game] = []
+  public weak var observer: GameModelObserver?
   
   public init(_ repo: GameRepository,
               andImageRepo imageRepo: GameImageRepositoryType) {
     self.repo = repo
     self.imageRepo = imageRepo
     
-    repo.subscribeToGameRepoGamesLoaded(subscriber: self, subscriberID: observerID)
+    repo.subscribeToRepository(subscriber: self)
     imageRepo.subscribeToRepository(withSubscriber: self)
     
   }
   
-  public var gameList: [Game] = []
-  
-  private var observers: [String: GameModelObserver] = [:]
-  
   private func notifyAllObservers() {
-    observers.forEach({ (observer) in
-      observer.value.gamesFinishedLoading()
-    })
+    observer?.gamesFinishedLoading()
   }
   
   private func loadGameDetails(of gameList: [Game]) {
@@ -54,20 +49,19 @@ extension GameModel: GameModelProtocol {
   public func getGameAt(index: Int) -> Game {
     
     if (index >= gameList.count) || (index <= -1) {
-      return Game(gameName: "No Game", gamePrice: 0.00)
+      return Game.defaultValue
     }
     
     return gameList[index]
     
   }
   
-  public func subscribeToGameModelGamesLoaded(subscriber observer: GameModelObserver,
-                                              subscriberID observerID: String) {
-    observers[observerID] = observer
+  public func subscribeToModel(subscriber observer: GameModelObserver) {
+    self.observer = observer
   }
 
-  public func unsubscribeFromGameModelGamesLoaded(subscriberID observerID: String) {
-    observers.removeValue(forKey: observerID)
+  public func unsubscribeFromModel() {
+    observer = nil
   }
 
 }
@@ -108,9 +102,7 @@ extension GameModel: GameImageRepoObserver {
     for index in 0..<gameList.count {
       
       if gameList[index].appID == game.appID {
-        observers.forEach({ (observer) in
-          observer.value.headerImageLoadedFor(game: game, at: index)
-        })
+        observer?.headerImageLoadedFor(game: game, at: index)
         return
       }
       

--- a/Source/GameView/Models/GameModelObservable.swift
+++ b/Source/GameView/Models/GameModelObservable.swift
@@ -9,9 +9,10 @@ import Foundation
 
 public protocol GameModelObservable {
   
-  func subscribeToGameModelGamesLoaded(subscriber observer: GameModelObserver,
-                                       subscriberID observerID: String)
+  var observer: GameModelObserver? { get }
+  
+  func subscribeToModel(subscriber observer: GameModelObserver)
 
-  func unsubscribeFromGameModelGamesLoaded(subscriberID observerID: String)
+  func unsubscribeFromModel()
 
 }

--- a/Source/GameView/Models/GameModelObserver.swift
+++ b/Source/GameView/Models/GameModelObserver.swift
@@ -8,9 +8,8 @@
 
 import Foundation
 
-public protocol GameModelObserver {
+public protocol GameModelObserver: AnyObject {
   
-  var observerID: String { get set }
   func gamesFinishedLoading()
   func headerImageLoadedFor(game: Game, at index: Int)
   

--- a/Source/GameView/Repositories/GameListRepository/GameAPIRepo.swift
+++ b/Source/GameView/Repositories/GameListRepository/GameAPIRepo.swift
@@ -41,7 +41,7 @@ fileprivate struct gameDetailsJSONResponseKeys {
 
 public class GameAPIRepo: GameRepository {
   
-  private var observers: [String: GameRepositoryObserver] = [:]
+  public weak var observer: GameRepositoryObserver?
   
   public init() { }
   
@@ -235,25 +235,20 @@ public class GameAPIRepo: GameRepository {
     
   }
   
-  public func subscribeToGameRepoGamesLoaded(subscriber observer: GameRepositoryObserver,
-                                             subscriberID observerID: String) {
-    observers[observerID] = observer
+  public func subscribeToRepository(subscriber observer: GameRepositoryObserver) {
+    self.observer = observer
   }
   
-  public func unsubscribeFromGameRepoGamesLoaded(subscriberID observerID: String) {
-    observers.removeValue(forKey: observerID)
+  public func unsubscribeFromRepository() {
+    observer = nil
   }
   
   private func notifyGameListLoaded(gameList: [Game]) {
-    observers.forEach({ (observer) in
-      observer.value.gameListFinishedLoading(withData: gameList)
-    })
+    observer?.gameListFinishedLoading(withData: gameList)
   }
   
   private func notifyGameDetailsLoaded(withData gameList: [Game]) {
-    observers.forEach({ (observer) in
-      observer.value.gameDetailsFinishedLoading(withData: gameList)
-    })
+    observer?.gameDetailsFinishedLoading(withData: gameList)
   }
   
 }

--- a/Source/GameView/Repositories/GameListRepository/GameRepositoryObservable.swift
+++ b/Source/GameView/Repositories/GameListRepository/GameRepositoryObservable.swift
@@ -9,9 +9,10 @@ import Foundation
 
 public protocol GameRepositoryObservable {
   
-  func subscribeToGameRepoGamesLoaded(subscriber observer: GameRepositoryObserver,
-                                      subscriberID observerID: String)
+  var observer: GameRepositoryObserver? { get }
+  
+  func subscribeToRepository(subscriber observer: GameRepositoryObserver)
 
-  func unsubscribeFromGameRepoGamesLoaded(subscriberID observerID: String)
+  func unsubscribeFromRepository()
   
 }

--- a/Source/GameView/Repositories/GameListRepository/GameRepositoryObserver.swift
+++ b/Source/GameView/Repositories/GameListRepository/GameRepositoryObserver.swift
@@ -7,8 +7,7 @@
 
 import Foundation
 
-public protocol GameRepositoryObserver {
-  var observerID: String { get set }
+public protocol GameRepositoryObserver: AnyObject {
   
   func gameListFinishedLoading(withData gameList: [Game])
   

--- a/Source/Login/Model/LoginModel.swift
+++ b/Source/Login/Model/LoginModel.swift
@@ -10,7 +10,7 @@ import Foundation
 
 public class LoginModel {
   
-  public var observer: LoginModelObserver?
+  public weak var observer: LoginModelObserver?
   private var repo: LoginRepositoryType
   
   public init(withRepo repo: LoginRepositoryType = LoginAPIRepo()) {

--- a/Source/Login/Model/LoginModelObservable.swift
+++ b/Source/Login/Model/LoginModelObservable.swift
@@ -9,7 +9,7 @@ import Foundation
 
 public protocol LoginModelObservable {
   
-  var observer: LoginModelObserver? { get set }
+  var observer: LoginModelObserver? { get }
   
   func subscribeToLoginModel(withSubscriber suscriber: LoginModelObserver)
   

--- a/Source/Login/Model/LoginModelObserver.swift
+++ b/Source/Login/Model/LoginModelObserver.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public protocol LoginModelObserver {
+public protocol LoginModelObserver: AnyObject {
   
   func authenticationAttemptFinished(withResult result: Bool)
   

--- a/Source/Login/Model/LoginModelType.swift
+++ b/Source/Login/Model/LoginModelType.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public protocol LoginModelType: LoginModelObservable{
+public protocol LoginModelType: LoginModelObservable {
   
   func attemptLogin(with username: String, and password: String)
   

--- a/Source/Login/Repositories/LoginAPIRepo.swift
+++ b/Source/Login/Repositories/LoginAPIRepo.swift
@@ -7,11 +7,16 @@
 
 import Foundation
 
-private struct JSONLoginResult: Codable {
-  let can_login: Bool
-}
-
 public class LoginAPIRepo {
+
+  struct JSONLoginResult: Codable {
+    let can_login: Bool
+  }
+
+  struct DataBundleKeys {
+    static let loginUsername: String = "username"
+    static let loginPassowrd: String = "password"
+  }
   
   public weak var observer: LoginRepositoryObserver?
   
@@ -41,10 +46,10 @@ extension LoginAPIRepo: LoginRepositoryType {
     let dataBundle = DataBundle()
     
     var loginParamters: [String: Any] = [:]
-    loginParamters["username"] = username
-    loginParamters["password"] = password
+    loginParamters[DataBundleKeys.loginUsername] = username
+    loginParamters[DataBundleKeys.loginPassowrd] = password
     
-    dataBundle.extraData["parameters"] = loginParamters
+    dataBundle.extraData[ServiceCallerDataBundleKeys.postParameters] = loginParamters
     
     serviceCaller.callFailed = { _ in
       self.observer?.authenticationAttemptFinished(withResult: false)
@@ -58,7 +63,7 @@ extension LoginAPIRepo: LoginRepositoryType {
     }
     
     do {
-      try serviceCaller.makeServiceCall(with: url, and: dataBundle, usingMethod: "POST")
+      try serviceCaller.makeServiceCall(with: url, and: dataBundle, usingMethod: .post)
     } catch {
       self.observer?.authenticationAttemptFinished(withResult: false)
     }
@@ -69,7 +74,7 @@ extension LoginAPIRepo: LoginRepositoryType {
     observer = subscriber
   }
   
-  public func unsunscribeFromLoginRepositoruy() {
+  public func unsunscribeFromLoginRepository() {
     observer = nil
   }
   

--- a/Source/Login/Repositories/LoginRepositoryObservable.swift
+++ b/Source/Login/Repositories/LoginRepositoryObservable.swift
@@ -9,10 +9,10 @@ import Foundation
 
 public protocol LoginRepositoryObservable {
   
-  var observer: LoginRepositoryObserver? { get set }
+  var observer: LoginRepositoryObserver? { get }
   
   func subscribeToLoginRepository(withSubscriber subscriber: LoginRepositoryObserver)
   
-  func unsunscribeFromLoginRepositoruy()
+  func unsunscribeFromLoginRepository()
   
 }

--- a/Source/Login/ViewModel/LoginViewModel.swift
+++ b/Source/Login/ViewModel/LoginViewModel.swift
@@ -35,11 +35,15 @@ extension LoginViewModel: LoginModelObserver {
   
   public func authenticationAttemptFinished(withResult result: Bool) {
     
+    guard let view = view else {
+      return
+    }
+    
     if result == true {
-      view?.authenticationSuccess()
+      view.authenticationSuccess()
       Analytics.logEvent(AnalyticsEventLogin, parameters: [:])
     } else {
-      view?.authenticationFailure()
+      view.authenticationFailure()
     }
     
   }

--- a/Source/ServiceCalls/FeistyAPIURLComponents.swift
+++ b/Source/ServiceCalls/FeistyAPIURLComponents.swift
@@ -9,10 +9,8 @@ import Foundation
 
 struct FeistyAPIURLComponents {
   
-  //private static let httpProtocol = "https://"
-  //private static let domainName = "feisty-server.herokuapp.com"
-  private static let httpProtocol = "http://"
-  private static let domainName = "localhost:8080"
+  private static let httpProtocol = "https://"
+  private static let domainName = "feisty-server.herokuapp.com"
   
   private static let friendsPath = "friends"
   private static let loginPath = "login"

--- a/Source/ServiceCalls/ServiceCaller.swift
+++ b/Source/ServiceCalls/ServiceCaller.swift
@@ -22,6 +22,11 @@ public struct ServiceCallerDataBundleKeys {
   static let postParameters: String = "parameters"
 }
 
+public enum HTTPMethod: String {
+  case get = "GET"
+  case post = "POST"
+}
+
 public class ServiceCaller {
   
   public var callSucceeded: ((Data, DataBundle) -> Void)?
@@ -30,7 +35,7 @@ public class ServiceCaller {
   
   public func makeServiceCall(with url: URL,
                               and dataBundle: DataBundle,
-                              usingMethod method: String = "GET") throws {
+                              usingMethod method: HTTPMethod = .get) throws {
     
     try checkIfCallerIsSetUp()
     
@@ -68,13 +73,13 @@ public class ServiceCaller {
   }
   
   private func setUpRequest(withURL url: URL,
-                            andWithMethod method: String,
+                            andWithMethod method: HTTPMethod,
                             andWithData data: DataBundle) -> URLRequest {
     
     var request = URLRequest(url: url)
-    request.httpMethod = method
+    request.httpMethod = method.rawValue
     
-    if method == "POST" {
+    if method == .post {
       post(request: &request, andWithData: data)
     }
     

--- a/Source/ShoppingCart/Model/ShoppingCartModel.swift
+++ b/Source/ShoppingCart/Model/ShoppingCartModel.swift
@@ -18,6 +18,7 @@ public class ShoppingCartModel {
 }
 
 extension ShoppingCartModel: ShoppingCartModelType {
+  
   public func getAmountInCart() -> Int {
     return shoppingCart.shoppingList.count
   }
@@ -25,6 +26,5 @@ extension ShoppingCartModel: ShoppingCartModelType {
   public func getGame(at index: Int) -> Game {
     return shoppingCart.shoppingList[index]
   }
-  
   
 }

--- a/Source/ShoppingCart/Model/ShoppingCartModelType.swift
+++ b/Source/ShoppingCart/Model/ShoppingCartModelType.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public protocol ShoppingCartModelType {
+public protocol ShoppingCartModelType: AnyObject {
   
   func getAmountInCart() -> Int
   func getGame(at index: Int) -> Game


### PR DESCRIPTION
<h1>Overview</h1>
Removed tech debt from the dev pod.

One of the common issues resolved is the way observers were set up. They were prone to retain cycles. Therefore the observers have been fixed from dictionary based to simple property based where each part of the MVVM cycle has 1 observer instead of a dictionary of observers.

<h2>Notes</h2>
A lot of files were changed but this is usually between 1 and 8 lines per file.